### PR TITLE
Don't stringify returned source

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,6 +35,6 @@ module.exports = function(source) {
         callback(null, JSON.stringify(mergedModule));
       });
   } else {
-    callback(null, JSON.stringify(source));
+    callback(null, source);
   }
 };


### PR DESCRIPTION
For modules that don't need to be merged. Don't stringify the returned
result, because it is already a string.